### PR TITLE
schedule: Add https to link to avoid bad rendering

### DIFF
--- a/src/data/schedule.ts
+++ b/src/data/schedule.ts
@@ -6,7 +6,7 @@ export type Event = {
     link?: string;
     when?: string;
   };
-  
+
   export const SCHEDULE: Event[] = [
     {
       label: "Open Doors",
@@ -179,7 +179,7 @@ export type Event = {
       name: "Klára Mikšíčková",
       title: "How to overcome overwhelm and reduce work stress",
       photo: "/speakers/klara.jpeg",
-      link: "www.kouc-miksickova.cz",
+      link: "https://www.kouc-miksickova.cz",
       when: "2024/02/24 5:12 PM UTC+1"
     },
     {


### PR DESCRIPTION
Links without https gets appended to the '/' from
the site, so the link from the current talk is rendered as https://prague.python.pizza/www.something....